### PR TITLE
Fix get_hydrogen_pops() to be consistent with read_idl_ascii

### DIFF
--- a/helita/sim/bifrost.py
+++ b/helita/sim/bifrost.py
@@ -1618,8 +1618,8 @@ class BifrostData(object):
             if os.access(tabfile, os.R_OK):
                 tabparams = read_idl_ascii(tabfile)
             if 'abund' in tabparams and 'aweight' in tabparams:
-                abund = np.array(tabparams['abund'].split()).astype('f')
-                aweight = np.array(tabparams['aweight'].split()).astype('f')
+                abund = tabparams['abund'].astype('f')
+                aweight = tabparams['aweight'].astype('f')
                 grph = calc_grph(abund, aweight)
             elif os.access(subsfile, os.R_OK):
                 grph = subs2grph(subsfile)


### PR DESCRIPTION
Changes in `read_idl_ascii()` now make it convert sequences of numbers as a string into arrays, while `get_hydrogen_pops()` still expected a string. This PR will fix that.