### PR TITLE
Allow concurrent reads of RH 1.5D output

### DIFF
--- a/helita/sim/bifrost.py
+++ b/helita/sim/bifrost.py
@@ -1630,7 +1630,7 @@ class BifrostData(object):
         return Quantity(nh, unit='1/cm3')
 
     def write_rh15d(self, outfile, desc=None, append=True, sx=slice(None),
-                    sy=slice(None), sz=slice(None)):
+                    sy=slice(None), sz=slice(None), write_all_v=False):
         """
         Writes snapshot in RH 1.5D format.
         Parameters
@@ -1646,6 +1646,8 @@ class BifrostData(object):
             Slice objects for x, y, and z dimensions, when not all points
             are needed. E.g. use slice(None) for all points, slice(0, 100, 2)
             for every second point up to 100.
+        write_all_v - bool, optional
+            If true, will write also the vx and vy components.
         Returns
         -------
         None.
@@ -1687,6 +1689,14 @@ class BifrostData(object):
 
         vz = cstagger.zup(self.pz)[sx, sy, sz] / rho
         vz *= -uv
+        if write_all_v:
+            vx = cstagger.xup(self.px)[sx, sy, sz] / rho
+            vx *= uv
+            vy = cstagger.yup(self.py)[sx, sy, sz] / rho
+            vy *= -uv
+        else:
+            vx = None
+            vy = None
         x = self.x[sx] * ul
         y = self.y[sy] * (-ul)
         z = self.z[sz] * (-ul)
@@ -1708,8 +1718,8 @@ class BifrostData(object):
             pbar.update()
             pbar.set_description("Writing to file")
         rh15d.make_xarray_atmos(outfile, temp, vz, z, nH=nh, ne=ne, x=x, y=y,
-                                append=append, Bx=Bx, By=By, Bz=Bz, desc=desc,
-                                snap=self.snap)
+                                vx=vx, vy=vy, Bx=Bx, By=By, Bz=Bz, desc=desc,
+                                append=append, snap=self.snap)
         if verbose:
             pbar.update()
 

--- a/helita/sim/rh15d.py
+++ b/helita/sim/rh15d.py
@@ -7,6 +7,7 @@ import datetime
 import numpy as np
 import xarray as xr
 import h5py
+import netCDF4
 from io import StringIO
 from astropy import units
 
@@ -33,11 +34,9 @@ class Rh15dout:
             infile = os.path.splitext(infile)[0] + '.ncdf'
         if not os.path.isfile(infile):
             return
-        f = h5py.File(infile, "r")
-        GROUPS = [g for g in f.keys() if type(f[g]) == h5py._hl.group.Group]
-        f.close()
+        GROUPS = netCDF4.Dataset(infile).groups.keys()
         for g in GROUPS:
-            setattr(self, g, xr.open_dataset(infile, group=g))
+            setattr(self, g, xr.open_dataset(infile, group=g, lock=None))
             self.files.append(getattr(self, g))
         if self.verbose:
             print(('--- Read %s file.' % infile))
@@ -50,7 +49,7 @@ class Rh15dout:
                 infile = os.path.splitext(infile)[0] + '.ncdf'
         if not os.path.isfile(infile):
             return
-        self.ray = xr.open_dataset(infile)
+        self.ray = xr.open_dataset(infile, lock=None)
         self.files.append(self.ray)
         if self.verbose:
             print(('--- Read %s file.' % infile))


### PR DESCRIPTION
Currently, trying to re-read output files from RH 1.5D will give an HDF5 error `Unable to open file (file close degree doesn't match)`. This is only because h5py is used to read the groups. This PR will fix this by using netCDF4 instead to read the groups.