### PR TITLE
Get rid of cstagger, use python module with numba

### DIFF
--- a/helita/sim/bifrost.py
+++ b/helita/sim/bifrost.py
@@ -1630,7 +1630,7 @@ class BifrostData(object):
         return Quantity(nh, unit='1/cm3')
 
     def write_rh15d(self, outfile, desc=None, append=True, sx=slice(None),
-                    sy=slice(None), sz=slice(None)):
+                    sy=slice(None), sz=slice(None), write_all_v=False):
         """
         Writes snapshot in RH 1.5D format.
         Parameters
@@ -1646,6 +1646,8 @@ class BifrostData(object):
             Slice objects for x, y, and z dimensions, when not all points
             are needed. E.g. use slice(None) for all points, slice(0, 100, 2)
             for every second point up to 100.
+        write_all_v - bool, optional
+            If true, will write also the vx and vy components.
         Returns
         -------
         None.
@@ -1687,6 +1689,14 @@ class BifrostData(object):
 
         vz = cstagger.zup(self.pz)[sx, sy, sz] / rho
         vz *= -uv
+        if write_all_v:
+            vx = cstagger.xup(self.px)[sx, sy, sz] / rho
+            vx *= uv
+            vy = cstagger.yup(self.py)[sx, sy, sz] / rho
+            vy *= -uv
+        else:
+            vx = None
+            vy = None
         x = self.x[sx] * ul
         y = self.y[sy] * (-ul)
         z = self.z[sz] * (-ul)
@@ -1708,8 +1718,8 @@ class BifrostData(object):
             pbar.update()
             pbar.set_description("Writing to file")
         rh15d.make_xarray_atmos(outfile, temp, vz, z, nH=nh, ne=ne, x=x, y=y,
-                                append=append, Bx=Bx, By=By, Bz=Bz, desc=desc,
-                                snap=self.snap)
+                                vx=vx, vy=vy, Bx=Bx, By=By, Bz=Bz, desc=desc,
+                                append=append, snap=self.snap)
         if verbose:
             pbar.update()
 

--- a/helita/sim/stagger.py
+++ b/helita/sim/stagger.py
@@ -1,0 +1,101 @@
+import numpy as np
+from numba import jit, njit, prange
+
+
+def do(var, operation='xup', pad_mode='wrap'):
+    """
+    Do a stagger operation on `var`. These are generally divided into
+    'up' or 'down' operations that interpolate values from cell faces
+    to cell centres (up), or from cell centres to cell faces (down).
+
+    Supported operations are currently:
+    * 'xup', 'xdn', 'yup', 'ydn', 'zup', 'zdn'.
+    """
+    op_func = {
+        'x': _xshift,
+        'y': _yshift,
+        'z': _zshift,
+    }
+    if operation[-2:].lower() == 'up':
+        up = True
+    elif operation[-2:].lower() == 'dn':
+        up = False
+    else: 
+        raise ValueError(f"Invalid operation {operation}")
+    op = operation[:-2]
+    if op not in op_func:
+        raise ValueError(f"Invalid operation {operation}")
+    func = op_func[op]
+    dim_index = 'xyz'.find(op[-1])
+    extra_dims = [(3, 2), (2, 3)][up]
+    padding = [(0, 0)] * 3
+    padding[dim_index] = extra_dims
+    s = var.shape
+    if s[dim_index] == 1:
+        return var
+    else:
+        out = np.pad(var, padding, mode=pad_mode)
+        return func(out, up=up)
+
+
+@njit(parallel=True)
+def _xshift(var, up=True):
+    c = 3.0 / 256.0
+    b = -25.0 / 256.0
+    a = 0.5 - b - c
+    if up:
+        sign = 1
+    else:
+        sign = -1
+    start = int(2.5 - sign*0.5)  
+    end = - int(2.5 + sign*0.5)
+    nx, ny, nz = var.shape
+    for k in prange(nz): 
+        for j in prange(ny):
+            for i in prange(start, nx + end):
+                var[i, j, k] = (a * (var[i, j, k] + var[i + sign, j, k]) +
+                                b * (var[i - sign*1, j, k] + var[i + sign*2, j, k]) +
+                                c * (var[i - sign*2, j, k] + var[i + sign*3, j, k]))
+    return var[start:end]
+
+
+@njit(parallel=True)
+def _yshift(var, up=True):
+    c = 3.0 / 256.0
+    b = -25.0 / 256.0
+    a = 0.5 - b - c
+    if up:
+        sign = 1
+    else:
+        sign = -1
+    start = int(2.5 - sign*0.5)  
+    end = - int(2.5 + sign*0.5)
+    nx, ny, nz = var.shape
+    for k in prange(nz): 
+        for j in prange(start, ny + end):
+            for i in prange(nx):
+                var[i, j, k] = (a * (var[i, j, k] + var[i, j + sign, k]) +
+                                b * (var[i, j - sign*1, k] + var[i, j + sign*2, k]) +
+                                c * (var[i, j - sign*2, k] + var[i, j + sign*3, k]))
+    return var[:, start:end]
+
+
+@njit(parallel=True)
+def _zshift(var, up=True):
+    c = 3.0 / 256.0
+    b = -25.0 / 256.0
+    a = 0.5 - b - c
+    if up:
+        sign = 1
+    else:
+        sign = -1
+    start = int(2.5 - sign*0.5)  
+    end = - int(2.5 + sign*0.5)
+    nx, ny, nz = var.shape
+    for k in prange(start, nz + end): 
+        for j in prange(ny):
+            for i in prange(nx):
+                var[i, j, k] = (a * (var[i, j, k] + var[i, j, k + sign]) +
+                                b * (var[i, j, k - sign*1] + var[i, j, k + sign*2]) +
+                                c * (var[i, j, k - sign*2] + var[i, j, k + sign*3]))
+    return var[..., start:end]

--- a/helita/sim/stagger.py
+++ b/helita/sim/stagger.py
@@ -2,16 +2,37 @@ import numpy as np
 from numba import jit, njit, prange
 
 
-def do(var, operation='xup', pad_mode=None):
+def do(var, operation='xup', diff=None, pad_mode=None):
     """
-    Do a stagger operation on `var`. These are generally divided into
-    'up' or 'down' operations that interpolate values from cell faces
-    to cell centres (up), or from cell centres to cell faces (down).
+    Do a stagger operation on `var` by doing a 6th order polynomial interpolation of 
+    the variable from cell centres to cell faces (down operations), or cell faces
+    to cell centres (up operations).
+    
+    Parameters
+    ----------
+    var : 3D array
+        Variable to work on.
+    operation: str
+        Type of operation. Currently supported values are
+        * 'xup', 'xdn', 'yup', 'ydn', 'zup', 'zdn'
+        * 'ddxup', 'ddxdn', 'ddyup', 'ddydn', 'ddzup', 'ddzdn' (derivatives)
+    diff: None or 1D array
+        If operation is one of the derivatives, you must supply `diff`,
+        an array with the distances between each cell in the direction of the
+        operation must be same length as array along that direction. 
+        For non-derivative operations, `diff` must be None.
+    pad_mode : str
+        Mode for padding array `var` to have enough points for a 6th order
+        polynomial interpolation. Same as supported by np.pad. Default is
+        `wrap` (periodic horizontal) for x and y, and `reflect` for z operations.
 
-    Supported operations are currently:
-    * 'xup', 'xdn', 'yup', 'ydn', 'zup', 'zdn'.
+    Returns
+    -------
+    3D array
+        Array of same type and dimensions to var, after performing the 
+        stagger operation.
     """
-    OPERATIONS = {
+    AXES = {
         'x': _xshift,
         'y': _yshift,
         'z': _zshift,
@@ -23,14 +44,25 @@ def do(var, operation='xup', pad_mode=None):
         up = False
     else: 
         raise ValueError(f"Invalid operation {operation}")
+    if operation[:2].lower() == 'dd':  # For derivative operations
+        derivative = True
+        operation = operation[2:]
+        if diff is None:
+            raise ValueError("diff not provided for derivative operation")
+    else:
+        derivative = False
+        if diff is not None:
+            raise ValueError("diff must not be provided for non-derivative operation")
     op = operation[:-2]
-    if op not in OPERATIONS:
+    if op not in AXES:
         raise ValueError(f"Invalid operation {operation}")
-    func = OPERATIONS[op]
+    func = AXES[op]
     if pad_mode is None:
         pad_mode = DEFAULT_PAD[op]
     dim_index = 'xyz'.find(op[-1])
     extra_dims = [(3, 2), (2, 3)][up]
+    if not derivative:
+        diff = np.ones(var.shape[dim_index], dtype=var.dtype)
     padding = [(0, 0)] * 3
     padding[dim_index] = extra_dims
     s = var.shape
@@ -38,67 +70,89 @@ def do(var, operation='xup', pad_mode=None):
         return var
     else:
         out = np.pad(var, padding, mode=pad_mode)
-        return func(out, up=up)
+        out_diff = np.pad(diff, extra_dims, mode=pad_mode)
+        return func(out, out_diff, up=up, derivative=derivative)
 
 
 @njit(parallel=True)
-def _xshift(var, up=True):
-    c = 3.0 / 256.0
-    b = -25.0 / 256.0
-    a = 0.5 - b - c
+def _xshift(var, diff, up=True, derivative=False):
     if up:
         sign = 1
     else:
         sign = -1
+    if derivative:
+        pm = -1
+        c = (-1 + (3**5 - 3) / (3**3 - 3)) / (5**5 - 5 - 5 * (3**5 - 3))
+        b = (-1 - 120*c) / 24
+        a = (1 - 3*b - 5*c)
+    else:
+        pm = 1
+        c = 3.0 / 256.0
+        b = -25.0 / 256.0
+        a = 0.5 - b - c
     start = int(2.5 - sign*0.5)  
     end = - int(2.5 + sign*0.5)
     nx, ny, nz = var.shape
     for k in prange(nz): 
         for j in prange(ny):
             for i in prange(start, nx + end):
-                var[i, j, k] = (a * (var[i, j, k] + var[i + sign, j, k]) +
-                                b * (var[i - sign*1, j, k] + var[i + sign*2, j, k]) +
-                                c * (var[i - sign*2, j, k] + var[i + sign*3, j, k]))
+                var[i, j, k] = diff[i] * (a * (var[i, j, k] + pm * var[i + sign, j, k]) +
+                                b * (var[i - sign*1, j, k] + pm * var[i + sign*2, j, k]) +
+                                c * (var[i - sign*2, j, k] + pm * var[i + sign*3, j, k]))
     return var[start:end]
 
 
 @njit(parallel=True)
-def _yshift(var, up=True):
-    c = 3.0 / 256.0
-    b = -25.0 / 256.0
-    a = 0.5 - b - c
+def _yshift(var, diff, up=True, derivative=False):
     if up:
         sign = 1
     else:
         sign = -1
+    if derivative:
+        pm = -1
+        c = (-1 + (3**5 - 3) / (3**3 - 3)) / (5**5 - 5 - 5 * (3**5 - 3))
+        b = (-1 - 120*c) / 24
+        a = (1 - 3*b - 5*c)
+    else:
+        pm = 1
+        c = 3.0 / 256.0
+        b = -25.0 / 256.0
+        a = 0.5 - b - c
     start = int(2.5 - sign*0.5)  
     end = - int(2.5 + sign*0.5)
     nx, ny, nz = var.shape
     for k in prange(nz): 
         for j in prange(start, ny + end):
             for i in prange(nx):
-                var[i, j, k] = (a * (var[i, j, k] + var[i, j + sign, k]) +
-                                b * (var[i, j - sign*1, k] + var[i, j + sign*2, k]) +
-                                c * (var[i, j - sign*2, k] + var[i, j + sign*3, k]))
+                var[i, j, k] = diff[j] * (a * (var[i, j, k] + pm * var[i, j + sign, k]) +
+                                b * (var[i, j - sign*1, k] + pm * var[i, j + sign*2, k]) +
+                                c * (var[i, j - sign*2, k] + pm * var[i, j + sign*3, k]))
     return var[:, start:end]
 
 
 @njit(parallel=True)
-def _zshift(var, up=True):
-    c = 3.0 / 256.0
-    b = -25.0 / 256.0
-    a = 0.5 - b - c
+def _zshift(var, diff, up=True, derivative=False):
     if up:
         sign = 1
     else:
         sign = -1
+    if derivative:
+        pm = -1
+        c = (-1 + (3**5 - 3) / (3**3 - 3)) / (5**5 - 5 - 5 * (3**5 - 3))
+        b = (-1 - 120*c) / 24
+        a = (1 - 3*b - 5*c)
+    else:
+        pm = 1
+        c = 3.0 / 256.0
+        b = -25.0 / 256.0
+        a = 0.5 - b - c
     start = int(2.5 - sign*0.5)  
     end = - int(2.5 + sign*0.5)
     nx, ny, nz = var.shape
     for k in prange(start, nz + end): 
         for j in prange(ny):
             for i in prange(nx):
-                var[i, j, k] = (a * (var[i, j, k] + var[i, j, k + sign]) +
-                                b * (var[i, j, k - sign*1] + var[i, j, k + sign*2]) +
-                                c * (var[i, j, k - sign*2] + var[i, j, k + sign*3]))
+                var[i, j, k] = diff[k] * (a * (var[i, j, k] + pm * var[i, j, k + sign]) +
+                                b * (var[i, j, k - sign*1] + pm * var[i, j, k + sign*2]) +
+                                c * (var[i, j, k - sign*2] + pm * var[i, j, k + sign*3]))
     return var[..., start:end]

--- a/helita/sim/stagger.py
+++ b/helita/sim/stagger.py
@@ -2,7 +2,7 @@ import numpy as np
 from numba import jit, njit, prange
 
 
-def do(var, operation='xup', pad_mode='wrap'):
+def do(var, operation='xup', pad_mode=None):
     """
     Do a stagger operation on `var`. These are generally divided into
     'up' or 'down' operations that interpolate values from cell faces
@@ -11,11 +11,12 @@ def do(var, operation='xup', pad_mode='wrap'):
     Supported operations are currently:
     * 'xup', 'xdn', 'yup', 'ydn', 'zup', 'zdn'.
     """
-    op_func = {
+    OPERATIONS = {
         'x': _xshift,
         'y': _yshift,
         'z': _zshift,
     }
+    DEFAULT_PAD = {'x': 'wrap', 'y': 'wrap', 'z': 'reflect'}
     if operation[-2:].lower() == 'up':
         up = True
     elif operation[-2:].lower() == 'dn':
@@ -23,9 +24,11 @@ def do(var, operation='xup', pad_mode='wrap'):
     else: 
         raise ValueError(f"Invalid operation {operation}")
     op = operation[:-2]
-    if op not in op_func:
+    if op not in OPERATIONS:
         raise ValueError(f"Invalid operation {operation}")
-    func = op_func[op]
+    func = OPERATIONS[op]
+    if pad_mode is None:
+        pad_mode = DEFAULT_PAD[op]
     dim_index = 'xyz'.find(op[-1])
     extra_dims = [(3, 2), (2, 3)][up]
     padding = [(0, 0)] * 3


### PR DESCRIPTION
This will get rid of all cstagger machinery, cython compilation, etc. and enable simpler functions for the stagger up/down operations.