### PR TITLE
Improve writing Stark broadening to YAML atoms

### DIFF
--- a/helita/sim/rh15d.py
+++ b/helita/sim/rh15d.py
@@ -1,7 +1,6 @@
 """
 Set of programs and tools to read the outputs from RH, 1.5D version
 """
-from ast import AnnAssign
 import os
 import warnings
 import datetime
@@ -607,7 +606,7 @@ class AtomFile:
                     line_dict['broadening_stark'] = {'coefficient': stark_tmp}
                     warnings.warn(
                         ("Stark coefficients given for Gray recipe (MULTI), which "
-                        "is not yet supported. Reverting to Traving recipe from RH."),
+                        "is not yet supported. Double check Stark coefficients."),
                         RuntimeWarning
                     )
                 coeff = float(line_i[ivdW][0])

--- a/helita/sim/rh15d.py
+++ b/helita/sim/rh15d.py
@@ -590,9 +590,9 @@ class AtomFile:
             else:
                 coeff = float(line_i[ivdW][0])
                 if coeff >= 20:
-                    # Recipe from MULTI
-                    sigma = int(coeff) * 2.80028E-21
-                    alpha = coeff - int(coeff)
+                    # Recipe from MULTI, not multiplying by a_0^2 here
+                    sigma = int(coeff)
+                    alpha = coeff - sigma
                     line_dict['broadening_vanderwaals'] = [
                         {'type': 'ABO', 
                          'σ': {'value': sigma, 


### PR DESCRIPTION
Edited `rh15d.AtomFile.write_yaml()` so that quadratic Stark broadening is written in a more consistent way, given the different approaches for RH and MULTI in reading the coefficients from the atom files.