### PR TITLE
Remove bloated dependencies

### DIFF
--- a/helita/sim/rh15d.py
+++ b/helita/sim/rh15d.py
@@ -551,9 +551,9 @@ class AtomFile:
                                        __level_str[line_i[1]]]
             line_dict['f_value'] = float(line_i[2])
             if line_i[ityp] == 'PRD':
-                line_dict['type_profile'] = 'PRD'
+                line_dict['profile_type'] = 'PRD'
             else:
-                line_dict['type_profile'] = (line_i[ityp][0] 
+                line_dict['profile_type'] = (line_i[ityp][0] 
                                                 + line_i[ityp][1:].lower())
             line_dict['broadening'] = []
             line_dict['broadening'].append({

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,8 @@ install_requires =
   scipy
   sunpy
   tqdm
-  xarray[io]
+  xarray
   numba
-  radynpy
 
 
 [options.extras_require]


### PR DESCRIPTION
`xarray[io]` adds a lot of bloat and unnecessary packages when running headless. This package should be able to be installed without extensive plotting ability, so please add the xarray io as option when necessary. 

Likewise, `radynpy` should be an optional dependency. It cannot be installed via conda/mamba and is unnecessary for most people.